### PR TITLE
Package alarm all force new

### DIFF
--- a/massdriver/resource_package_alarm.go
+++ b/massdriver/resource_package_alarm.go
@@ -117,31 +117,6 @@ func resourcePackageAlarmCreate(ctx context.Context, d *schema.ResourceData, m i
 	return diags
 }
 
-func resourcePackageAlarmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*MassdriverClient)
-
-	var diags diag.Diagnostics
-
-	packageAlarmMeta := PackageAlarmMetadata{
-		ResourceIdentifier: d.Get("cloud_resource_id").(string),
-		DisplayName:        d.Get("display_name").(string),
-		Metric:             parseMetricBock(d.Get("metric").([]interface{})),
-	}
-
-	event := NewEvent(EVENT_TYPE_ALARM_CHANNEL_UPDATED)
-	event.Payload = EventPayloadAlarmChannels{DeploymentId: c.DeploymentID, PackageAlarm: packageAlarmMeta}
-
-	err := c.PublishEventToSNS(event, &diags)
-
-	if err != nil {
-		return diags
-	}
-
-	d.Set("last_updated", time.Now().Format(time.RFC850))
-
-	return diags
-}
-
 func resourcePackageAlarmDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*MassdriverClient)
 

--- a/massdriver/resource_package_alarm.go
+++ b/massdriver/resource_package_alarm.go
@@ -27,7 +27,6 @@ func resourcePackageAlarm() *schema.Resource {
 
 		CreateContext: resourcePackageAlarmCreate,
 		ReadContext:   schema.NoopContext,
-		UpdateContext: resourcePackageAlarmUpdate,
 		DeleteContext: resourcePackageAlarmDelete,
 
 		Schema: map[string]*schema.Schema{
@@ -40,11 +39,13 @@ func resourcePackageAlarm() *schema.Resource {
 			"display_name": {
 				Description: "The name to display in the massdriver UI",
 				Type:        schema.TypeString,
+				ForceNew:    true,
 				Required:    true,
 			},
 			"metric": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
+				ForceNew: true,
 				Optional: true, // This should be removed when we've added it to all our existing alarms
 				//Required: false,     This should be set to true when we've added it to all our existing alarms
 				Elem: &schema.Resource{
@@ -52,21 +53,25 @@ func resourcePackageAlarm() *schema.Resource {
 						"name": {
 							Type:        schema.TypeString,
 							Description: "Name of the metric. Required for all clouds.",
+							ForceNew:    true,
 							Required:    true,
 						},
 						"namespace": {
 							Type:        schema.TypeString,
 							Description: "Namespace of the metric. Required for AWS and Azure. Omit for GCP.",
+							ForceNew:    true,
 							Required:    true,
 						},
 						"statistic": {
 							Type:        schema.TypeString,
 							Description: "Aggregation method (sum, average, maximum, etc.)",
+							ForceNew:    true,
 							Optional:    true,
 						},
 						"dimensions": {
 							Type:        schema.TypeMap,
 							Description: "The filtering criteria for the metric",
+							ForceNew:    true,
 							Optional:    true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,


### PR DESCRIPTION
This will make it so any changes to any field in `massdriver_package_alarm` will trigger a delete/recreate