### PR TITLE
HOTFIX: Fix type conversion panic in massdriver_package_alarm

### DIFF
--- a/massdriver/resource_package_alarm.go
+++ b/massdriver/resource_package_alarm.go
@@ -20,7 +20,7 @@ type PackageAlarmMetadata struct {
 	DisplayName        string              `json:"display_name"`
 	Metric             *PackageAlarmMetric `json:"metric,omitempty"`
 	Threshold          float64             `json:"threshold,omitempty"`
-	PeriodMinutes      int64               `json:"period_minutes,omitempty"`
+	PeriodMinutes      int                 `json:"period_minutes,omitempty"`
 	ComparisonOperator string              `json:"comparsion_operator,omitempty"`
 }
 
@@ -122,7 +122,7 @@ func resourcePackageAlarmCreate(ctx context.Context, d *schema.ResourceData, m i
 		DisplayName:        d.Get("display_name").(string),
 		Metric:             parseMetricBock(d.Get("metric").([]interface{})),
 		Threshold:          d.Get("threshold").(float64),
-		PeriodMinutes:      d.Get("period_minutes").(int64),
+		PeriodMinutes:      d.Get("period_minutes").(int),
 		ComparisonOperator: d.Get("comparison_operator").(string),
 	}
 
@@ -151,7 +151,7 @@ func resourcePackageAlarmDelete(ctx context.Context, d *schema.ResourceData, m i
 		DisplayName:        d.Get("display_name").(string),
 		Metric:             parseMetricBock(d.Get("metric").([]interface{})),
 		Threshold:          d.Get("threshold").(float64),
-		PeriodMinutes:      d.Get("period_minutes").(int64),
+		PeriodMinutes:      d.Get("period_minutes").(int),
 		ComparisonOperator: d.Get("comparison_operator").(string),
 	}
 


### PR DESCRIPTION
Fixing this error showing up:

```
{"@level":"error","@message":"Error: Request cancelled","@module":"terraform.ui","@timestamp":"2024-06-05T21:41:38.825239Z","diagnostic":{"severity":"error","summary":"Request cancelled","detail":"The plugin.(*GRPCProvider).ValidateResourceConfig request was cancelled.","address":"massdriver_artifact.table","range":{"filename":"_artifacts.tf","start":{"line":1,"column":40,"byte":39},"end":{"line":1,"column":41,"byte":40}},"snippet":{"context":"resource \"massdriver_artifact\" \"table\"","code":"resource \"massdriver_artifact\" \"table\" {","start_line":1,"highlight_start_offset":39,"highlight_end_offset":40,"values":[]}},"type":"diagnostic"}
{"@level":"error","@message":"Error: Plugin did not respond","@module":"terraform.ui","@timestamp":"2024-06-05T21:41:38.829466Z","diagnostic":{"severity":"error","summary":"Plugin did not respond","detail":"The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain more details.","address":"massdriver_package_alarm.write_capacity[0]","range":{"filename":"monitoring.tf","start":{"line":118,"column":54,"byte":3205},"end":{"line":118,"column":55,"byte":3206}},"snippet":{"context":"resource \"massdriver_package_alarm\" \"write_capacity\"","code":"resource \"massdriver_package_alarm\" \"write_capacity\" {","start_line":118,"highlight_start_offset":53,"highlight_end_offset":54,"values":[]}},"type":"diagnostic"}
{"@level":"error","@message":"Error: Plugin did not respond","@module":"terraform.ui","@timestamp":"2024-06-05T21:41:38.832019Z","diagnostic":{"severity":"error","summary":"Plugin did not respond","detail":"The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain more details.","address":"massdriver_package_alarm.read_capacity[0]","range":{"filename":"monitoring.tf","start":{"line":62,"column":53,"byte":1611},"end":{"line":62,"column":54,"byte":1612}},"snippet":{"context":"resource \"massdriver_package_alarm\" \"read_capacity\"","code":"resource \"massdriver_package_alarm\" \"read_capacity\" {","start_line":62,"highlight_start_offset":52,"highlight_end_offset":53,"values":[]}},"type":"diagnostic"}
{"level":"info","provisioner":"terraform","output":"backend.tf.json","step":"src","bucket":"xo-prod-tfstate-0000","organization-id":"ab94398f-d33a-48c8-b3a9-ec8c8ec30e5b","package-id":"ca746463-0d8f-4a12-a768-87798e4b07af","region":"us-west-2","dynamodb-table":"arn:aws:dynamodb:us-west-2:308878630280:table/xo-prod-tfstate-0000-lock","time":"2024-06-05T21:41:15Z","message":"Generating state file"}

Stack trace from the terraform-provider-massdriver_v1.2.0 plugin:

panic: interface conversion: interface {} is int, not int64

goroutine 36 [running]:
terraform-provider-massdriver/massdriver.resourcePackageAlarmCreate({0xf305e0, 0xc0003f6c90}, 0xc00012b028, {0xcffa40, 0xc00007df00})
	terraform-provider-massdriver/massdriver/resource_package_alarm.go:125 +0x4c5
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xc00037a380, {0xf305e0, 0xc0003f6c90}, 0xd, {0xcffa40, 0xc00007df00})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.16.0/helper/schema/resource.go:707 +0x12e
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc00037a380, {0xf305e0, 0xc0003f6c90}, 0xc0003f4c30, 0xc0003fcd00, {0xcffa40, 0xc00007df00})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.16.0/helper/schema/resource.go:837 +0xc29
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc00000d1a0, {0xf30538, 0xc0003e8bc0}, 0xc0003ec7d0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.16.0/helper/schema/grpc_provider.go:1021 +0xe3c
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc0002cfea0, {0xf305e0, 0xc0003f64b0}, 0xc0003b1b20)
	github.com/hashicorp/terraform-plugin-go@v0.9.1/tfprotov5/tf5server/server.go:812 +0x56b
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0xdb7720, 0xc0002cfea0}, {0xf305e0, 0xc0003f64b0}, 0xc0003e6c60, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.9.1/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:385 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00029ca80, {0xf3eca0, 0xc00023a9c0}, 0xc000481e60, 0xc000390030, 0x14f7a20, 0x0)
	google.golang.org/grpc@v1.46.2/server.go:1283 +0xcf2
google.golang.org/grpc.(*Server).handleStream(0xc00029ca80, {0xf3eca0, 0xc00023a9c0}, 0xc000481e60, 0x0)
	google.golang.org/grpc@v1.46.2/server.go:1620 +0xa2a
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	google.golang.org/grpc@v1.46.2/server.go:922 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.46.2/server.go:920 +0x294

Error: The terraform-provider-massdriver_v1.2.0 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```