### PR TITLE
Add artifact data source and switch to dot-separated identifier format

### DIFF
--- a/massdriver/datasource_artifact.go
+++ b/massdriver/datasource_artifact.go
@@ -1,0 +1,91 @@
+package massdriver
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceArtifact() *schema.Resource {
+	return &schema.Resource{
+		Description: `Looks up an existing Massdriver artifact by its identifier.
+
+This data source enables inter-step data passing by allowing one bundle to read
+artifacts produced by another bundle. This is useful for:
+
+- Accessing infrastructure outputs from shared resources (VPCs, clusters, etc.)
+- Reading credentials or connection details from other packages
+- Building dependencies between packages that aren't directly linked on the canvas
+
+## Artifact Identifier Format
+
+The identifier format uses a dot to separate the package ID from the artifact field:
+
+    {package_id}.{artifact_field}
+
+Example: "api-prod-database.credentials"
+`,
+
+		ReadContext: dataSourceArtifactRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The artifact identifier in the format `{package_id}.{field}` (e.g., `api-prod-db.credentials`).",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"name": {
+				Description: "The human-readable name of the artifact.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"type": {
+				Description: "The artifact type (artifact definition reference).",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"field": {
+				Description: "The field name of the artifact within the source package.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"payload": {
+				Description: "The artifact payload as a JSON string. Use `jsondecode()` to access individual fields.",
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+			},
+		},
+	}
+}
+
+func dataSourceArtifactRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	service := meta.(*ProviderClient).ArtifactService()
+
+	var diags diag.Diagnostics
+
+	id := d.Get("id").(string)
+
+	artifact, err := service.GetArtifact(ctx, id)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(artifact.ID)
+	d.Set("name", artifact.Name)
+	d.Set("type", artifact.Type)
+	d.Set("field", artifact.Field)
+
+	// Serialize payload to JSON string
+	if artifact.Payload != nil {
+		payloadJSON, err := json.Marshal(artifact.Payload)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		d.Set("payload", string(payloadJSON))
+	}
+
+	return diags
+}

--- a/massdriver/datasource_artifact_test.go
+++ b/massdriver/datasource_artifact_test.go
@@ -1,0 +1,53 @@
+package massdriver
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccMassdriverArtifactDataSourceBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckMassdriverArtifactDataSourceConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMassdriverArtifactDataSourceExists("data.massdriver_artifact.test"),
+					resource.TestCheckResourceAttrSet("data.massdriver_artifact.test", "name"),
+					resource.TestCheckResourceAttrSet("data.massdriver_artifact.test", "type"),
+					resource.TestCheckResourceAttrSet("data.massdriver_artifact.test", "payload"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMassdriverArtifactDataSourceConfigBasic() string {
+	// Note: This test requires an existing artifact in the test environment
+	// The artifact ID should use the dot-separated format: project-env-manifest.field
+	return `
+	data "massdriver_artifact" "test" {
+		id = "test-env-pkg.test-artifact"
+	}
+	`
+}
+
+func testAccCheckMassdriverArtifactDataSourceExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID set")
+		}
+
+		return nil
+	}
+}

--- a/massdriver/provider.go
+++ b/massdriver/provider.go
@@ -15,7 +15,9 @@ func Provider() *schema.Provider {
 			"massdriver_artifact":      resourceArtifact(),
 			"massdriver_package_alarm": resourcePackageAlarm(),
 		},
-		DataSourcesMap:       map[string]*schema.Resource{},
+		DataSourcesMap: map[string]*schema.Resource{
+			"massdriver_artifact": dataSourceArtifact(),
+		},
 		ConfigureContextFunc: providerConfigure,
 	}
 }

--- a/massdriver/resource_artifact.go
+++ b/massdriver/resource_artifact.go
@@ -164,13 +164,25 @@ func resourceArtifactDelete(ctx context.Context, d *schema.ResourceData, meta an
 	return diags
 }
 
+// getID returns the artifact identifier.
+//
+// When MASSDRIVER_PACKAGE_ID is set, uses dot-separated format: {package_id}.{field}
+// Falls back to MASSDRIVER_PACKAGE_NAME with dash separator for backward compatibility.
 func getID(d *schema.ResourceData) string {
 	artifactID := d.Id()
 
-	// If the ID is a timestamp, it was from the older system where we didn't have IDs. We need to convert the ID to the new format, which is <package_name>-<field>
+	// If the ID is a timestamp, it was from the older system where we didn't have IDs.
 	if _, err := time.Parse(time.RFC3339, artifactID); err == nil {
-		packageName := os.Getenv("MASSDRIVER_PACKAGE_NAME")
-		artifactID = fmt.Sprintf("%s-%s", packageName, d.Get("field"))
+		field := d.Get("field").(string)
+		packageID := os.Getenv("MASSDRIVER_PACKAGE_ID")
+		if packageID != "" {
+			// New format: dot-separated
+			artifactID = fmt.Sprintf("%s.%s", packageID, field)
+		} else {
+			// Backward compatibility: dash-separated with MASSDRIVER_PACKAGE_NAME
+			packageName := os.Getenv("MASSDRIVER_PACKAGE_NAME")
+			artifactID = fmt.Sprintf("%s-%s", packageName, field)
+		}
 	}
 	return artifactID
 }


### PR DESCRIPTION
## Summary
- Updated artifact identifier format to use dot-separation: `{package_slug}.{field}`
- Added new `massdriver_artifact` data source for looking up existing artifacts

## Artifact Identifier Format

The new preferred format uses a dot to separate the package slug from the artifact field:

```
api-prod-database.credentials
```

This makes it unambiguous where the package slug ends and the artifact field begins, which is easier for both humans and machines to parse.

### Backward Compatibility

The backend supports all three formats:
| Format | Example | Status |
|--------|---------|--------|
| `slug.field` | `api-prod-db.vpc` | **New preferred** |
| `slug-field` | `api-prod-db-vpc` | Legacy (supported) |
| `name_prefix-field` | `api-prod-db-x123-vpc` | Terraform legacy (supported) |

## New Data Source: `massdriver_artifact`

```hcl
data "massdriver_artifact" "primary_db" {
  id = "api-prod-database.primary"
}

# Access the artifact payload
locals {
  hostname = jsondecode(data.massdriver_artifact.primary_db.payload).hostname
}
```

### Use Cases
- Accessing infrastructure outputs from shared resources (VPCs, clusters, etc.)
- Reading credentials or connection details from other packages
- Building dependencies between packages that aren't directly linked on the canvas

## Test plan
- [x] Code compiles (`go build ./...`)
- [x] Added basic test for data source
- [ ] Manual testing with actual Massdriver environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)